### PR TITLE
Processor Intune App Cleaner

### DIFF
--- a/IntuneUploader/IntuneAppCleaner.py
+++ b/IntuneUploader/IntuneAppCleaner.py
@@ -1,0 +1,106 @@
+#!/usr/local/autopkg/python
+
+"""
+This processor cleans up apps in Intune based on the input variables. 
+It will keep the number of versions specified in the keep_version_count variable. It will delete the rest.
+
+Created by Tobias Almén
+"""
+
+import sys 
+import os
+
+from autopkglib import Processor, ProcessorError
+
+__all__ = ["IntuneAppCleaner"]
+
+sys.path.insert(0, os.path.dirname(__file__))
+from IntuneUploaderLib.IntuneUploaderBase import IntuneUploaderBase
+
+class IntuneAppCleaner(IntuneUploaderBase):
+    """This processor cleans up apps in Intune based on the input variables."""
+
+    description = __doc__
+    input_variables = {
+        "display_name": {
+            "required": True,
+            "description": "The name of the app to clean up.",
+        },
+        "keep_version_count": {
+            "required": False,
+            "description": "The number of versions to keep. Defaults to 3.",
+            "default": 3,
+        },
+        "test_mode": {
+            "required": False,
+            "description": "If True, will only print what would have been done.",
+            "default": False,
+        },
+    }
+    output_variables = {
+        "intuneappcleaner_summary_result": {"description": "Description of interesting results."}
+    }
+
+    def main(self):
+        # Set variables
+        self.BASE_ENDPOINT = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps"
+        self.CLIENT_ID = self.env.get("CLIENT_ID")
+        self.CLIENT_SECRET = self.env.get("CLIENT_SECRET")
+        self.TENANT_ID = self.env.get("TENANT_ID")
+        app_name = self.env.get("display_name")
+        keep_versions = self.env.get("keep_version_count")
+        apps_to_delete = []
+        test_mode = self.env.get("test_mode")
+        
+        # Get access token
+        self.token = self.obtain_accesstoken(self.CLIENT_ID, self.CLIENT_SECRET, self.TENANT_ID)
+        
+        
+        # When running from the command line, keep_versions is a string, convert to int
+        if type(keep_versions) is not int:
+            keep_versions = int(keep_versions)
+        
+        # Get macthing apps
+        apps = self.get_matching_apps(app_name)
+        self.output(f"Found {str(len(apps))} apps matching {app_name}")
+        
+        if len(apps) == 0:
+            return None
+        
+        # Get a sorted list of apps by version
+        apps = sorted(apps, key=lambda app: app["primaryBundleVersion"], reverse=True)
+        
+        # If the number of apps is greater than the keep version count, remove the apps that should be kept
+        if len(apps) > keep_versions:
+            self.output("App count is greater than keep version count, removing apps.")
+            # Remove the apps that should be kept
+            apps_to_delete = apps[keep_versions:]
+            
+            # Delete the apps that should not be kept
+            for app in apps_to_delete:
+                self.output("Deleted app: " + app["displayName"] + " " + app["primaryBundleVersion"])
+                # Only delete if not in test mode
+                if not test_mode:
+                    self.makeapirequestDelete(self.BASE_ENDPOINT + "/" + app["id"], self.token)
+                
+        self.env["intuneappcleaner_summary_result"] = {
+            "summary_text": "Summary of IntuneAppCleaner results:",
+            "report_fields": [
+                "searched name",
+                "keep count",
+                "match count",
+                "removed count",
+                "removed versions"
+            ],
+            "data": {
+                "searched name": app_name,
+                "keep count": str(keep_versions),
+                "match count": str(len(apps)),
+                "removed count": str(len(apps_to_delete)),
+                "removed versions": ", ".join([app["primaryBundleVersion"] for app in apps_to_delete]) if len(apps_to_delete) > 0 else ""
+            },
+        }
+
+if __name__ == "__main__":
+    PROCESSOR = IntuneAppCleaner()
+    PROCESSOR.execute_shell()

--- a/IntuneUploader/IntuneAppCleaner.py
+++ b/IntuneUploader/IntuneAppCleaner.py
@@ -10,8 +10,6 @@ Created by Tobias Almén
 import sys 
 import os
 
-from autopkglib import Processor, ProcessorError
-
 __all__ = ["IntuneAppCleaner"]
 
 sys.path.insert(0, os.path.dirname(__file__))

--- a/IntuneUploader/IntuneAppIconGetter.py
+++ b/IntuneUploader/IntuneAppIconGetter.py
@@ -1,3 +1,13 @@
+#!/usr/local/autopkg/python
+
+"""
+This processor extracts the app icon from a .app or .dmg file and saves it as a .png file.
+This is a very basic processor that uses the sips command to convert the icon to png format.
+For more advanced icon extraction, use the AppIconExtractor processor.
+
+Created by Tobias Almén
+"""
+
 import glob
 import os
 import plistlib
@@ -7,9 +17,7 @@ from autopkglib import DmgMounter
 
 
 class IntuneAppIconGetter(DmgMounter):
-    """Extracts the app icon from a .app or .dmg file and saves it as a .png file.
-    This is a very basic processor that uses the sips command to convert the icon to png format.
-    For more advanced icon extraction, use the AppIconExtractor processor."""
+    """Extracts the app icon from a .app or .dmg file and saves it as a .png file."""
 
     input_variables = {
         "app_file": {

--- a/IntuneUploader/IntuneAppUploader.py
+++ b/IntuneUploader/IntuneAppUploader.py
@@ -240,6 +240,8 @@ class IntuneAppUploader(IntuneUploaderBase):
         current_app_result, current_app_data = self.get_current_app(app_displayname, app_bundleVersion)
 
         # If the ignore_current_app variable is set to true, create the app regardless of whether it already exists
+        if ignore_current_app and not current_app_data:
+            raise ProcessorError("App not found in Intune. Please set ignore_current_app to false.")
         if ignore_current_app and app_bundleVersion != current_app_data["primaryBundleVersion"]:
             self.output(f"Creating app {app_data.displayName} version {app_bundleVersion}")
             # Create the app

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Ideas for future processors:
 For getting started help and documentation, please visit the wiki pages:
 - [Intune App Uploader](https://github.com/almenscorner/intune-uploader/wiki/IntuneAppUploader)
 - [Intune App Icon Getter](https://github.com/almenscorner/intune-uploader/wiki/IntuneAppIconGetter)
+- [Intune App Cleaner](https://github.com/almenscorner/intune-uploader/wiki/IntuneAppCleaner)
 
 ### IntuneAppUploader - PKG type apps (not LOB)
 All code in this processor for PKG support is currently made on assumptions of how the API will look like. This means that the code might break if the production API looks different. Once the API is finalized, the code will be updated to reflect the production API.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Moving forward, additional processors for Intune might be added to this project 
 
 Ideas for future processors:
 - Shell script processor
-- App removal processor
 - Teams notifier processor
 
 For getting started help and documentation, please visit the wiki pages:


### PR DESCRIPTION
Added a new processor for cleaning up old versions of applications in Intune. Should be used as a post-processor when running recipes.

Example:

```bash
autopkg run -v \
--post com.github.almenscorner.intune-upload.processors/IntuneAppCleaner \
-k display_name=AltTab \
-k test_mode=True \
-k keep_version_count=5 \
AltTab.intune.recipe
```