### PR TITLE
LOB apps

### DIFF
--- a/IntuneUploader/IntuneAppCleaner.py
+++ b/IntuneUploader/IntuneAppCleaner.py
@@ -61,10 +61,12 @@ class IntuneAppCleaner(IntuneUploaderBase):
         # Get macthing apps
         apps = self.get_matching_apps(app_name)
         self.output(f"Found {str(len(apps))} apps matching {app_name}")
-        
+
         if len(apps) == 0:
             return None
         
+        # Get primaryBundleVersion or buildNumber for each app and set it as a key in the app dict
+        apps = list(map(lambda item: {**item, 'primaryBundleVersion': item['buildNumber']} if 'primaryBundleVersion' not in item and 'buildNumber' in item else item, apps))
         # Get a sorted list of apps by version
         apps = sorted(apps, key=lambda app: app["primaryBundleVersion"], reverse=True)
         
@@ -73,7 +75,6 @@ class IntuneAppCleaner(IntuneUploaderBase):
             self.output("App count is greater than keep version count, removing apps.")
             # Remove the apps that should be kept
             apps_to_delete = apps[keep_versions:]
-            
             # Delete the apps that should not be kept
             for app in apps_to_delete:
                 self.output("Deleted app: " + app["displayName"] + " " + app["primaryBundleVersion"])

--- a/README.md
+++ b/README.md
@@ -15,4 +15,10 @@ For getting started help and documentation, please visit the wiki pages:
 - [Intune Script Uploader](https://github.com/almenscorner/intune-uploader/wiki/IntuneScriptUploader)
 
 ### IntuneAppUploader - LOB apps (managed PKG)
-LOB type apps will remain not supported by this processor. This is because LOB apps have limitations which the new PKG type does not have. For example, LOB apps does not support payload free packages, and the package must be signed. This is not the case for PKG type apps.
+LOB type apps support has been added. It is required that you provide a pkg file that is signed with a valid Apple Developer ID certificate and notarized. This app type can be deploy apps in a "available" manner rather than "required". This means that the user can choose to install the app or not. This is useful for apps that are not required for the user to do their job, but are nice to have.
+
+In the override file for a signed and notarized pkg, set the following key to upload as a LOB app:
+```xml
+<key>lob_app</key>
+<true/>
+```


### PR DESCRIPTION
LOB type apps support has been added. It is required that you provide a pkg file that is signed with a valid Apple Developer ID certificate and notarized. This app type can be deploy apps in a "available" manner rather than "required". This means that the user can choose to install the app or not. This is useful for apps that are not required for the user to do their job, but are nice to have.

In the override file for a signed and notarized pkg, set the following key to upload as a LOB app:

```xml
<key>lob_app</key>
<true/>
```