### PR TITLE
bugfix not supported between instances

### DIFF
--- a/IntuneUploader/IntuneAppCleaner.py
+++ b/IntuneUploader/IntuneAppCleaner.py
@@ -63,7 +63,7 @@ class IntuneAppCleaner(IntuneUploaderBase):
         )
 
         # When running from the command line, keep_versions is a string, convert to int
-        if isinstance(keep_versions, int):
+        if isinstance(keep_versions, str):
             keep_versions = int(keep_versions)
 
         # Get macthing apps

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Pull requests are welcome!
 Some ground rules before submitting a PR,
 * Install [pre-commit](https://pre-commit.com)
    * Once installed, run `pre-commit install` in the forked repo
-* Make sure all tests pass before submitting a PR 
+* Make sure all tests pass before submitting a PR


### PR DESCRIPTION
Running IntuneAppCleaner failed with `'>' not supported between instances of 'int' and 'str'` as it was not converting the str to an int.

closes #12 