### PR TITLE
Version issue during promotion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,5 @@ cython_debug/
 .idea/
 
 .DS_Store
+
+.vscode/


### PR DESCRIPTION
The version of the app was being set as a ENV var during the run based on the recipe which caused an issue where if multiple versions of an app existed, the output always showed the latest version. This PR sets the version based on the app in Intune instead to get correct information on what has been promoted.