### PR TITLE
add option to add group as exclude

### DIFF
--- a/IntuneUploader/IntuneAppUploader.py
+++ b/IntuneUploader/IntuneAppUploader.py
@@ -453,6 +453,9 @@ class IntuneAppUploader(IntuneUploaderBase):
             self.update_categories(app_categories, self.request.get("categories"))
 
         if app_assignment_info:
+            for assignment in app_assignment_info:
+                if "exclude" not in assignment:
+                    assignment["exclude"] = False
             self.assign_app(app_data, app_assignment_info)
 
         self.env["intune_app_changed"] = True

--- a/IntuneUploader/IntuneUploaderLib/IntuneUploaderBase.py
+++ b/IntuneUploader/IntuneUploaderLib/IntuneUploaderBase.py
@@ -611,11 +611,15 @@ class IntuneUploaderBase(Processor):
         if missing_assignment:
             for assignment in missing_assignment:
                 # Assign the app to the group
+                if assignment["exclude"] is True:
+                    odata_type = "#microsoft.graph.exclusionGroupAssignmentTarget"
+                else:
+                    odata_type = "#microsoft.graph.groupAssignmentTarget"
                 data["mobileAppAssignments"].append(
                     {
                         "@odata.type": "#microsoft.graph.mobileAppAssignment",
                         "target": {
-                            "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+                            "@odata.type": odata_type,
                             "groupId": assignment["group_id"],
                         },
                         "intent": assignment["intent"],


### PR DESCRIPTION
Added new option for assigning a group using the Exclude target.

To exclude a group, add `exclude` to `assignment_info` and set to `true`.

```xml
<key>assignment_info</key>
<array>
    <dict>
        <key>exclude</key>
        <true/>
        <key>group_id</key>
        <string>xxxx-xxxxx-xxxxx-xxxxxx</string>
        <key>intent</key>
        <string>Required</string>
    </dict>
</array>
```