### PR TITLE
Add support for certificate-based authentication in IntuneUploader

### DIFF
--- a/IntuneUploader/IntuneAppCleaner.py
+++ b/IntuneUploader/IntuneAppCleaner.py
@@ -51,6 +51,8 @@ class IntuneAppCleaner(IntuneUploaderBase):
         )
         self.CLIENT_ID = self.env.get("CLIENT_ID")
         self.CLIENT_SECRET = self.env.get("CLIENT_SECRET")
+        self.CLIENT_CERTIFICATE_PATH = self.env.get("CLIENT_CERTIFICATE_PATH")
+        self.CLIENT_CERTIFICATE_PASSWORD = self.env.get("CLIENT_CERTIFICATE_PASSWORD")
         self.TENANT_ID = self.env.get("TENANT_ID")
         app_name = self.env.get("display_name")
         keep_versions = self.env.get("keep_version_count")
@@ -59,7 +61,11 @@ class IntuneAppCleaner(IntuneUploaderBase):
 
         # Get access token
         self.token = self.obtain_accesstoken(
-            self.CLIENT_ID, self.CLIENT_SECRET, self.TENANT_ID
+            self.CLIENT_ID,
+            self.CLIENT_SECRET,
+            self.TENANT_ID,
+            cert_path=self.CLIENT_CERTIFICATE_PATH,
+            cert_password=self.CLIENT_CERTIFICATE_PASSWORD,
         )
 
         # When running from the command line, keep_versions is a string, convert to int

--- a/IntuneUploader/IntuneAppPromoter.py
+++ b/IntuneUploader/IntuneAppPromoter.py
@@ -59,6 +59,8 @@ class IntuneAppPromoter(IntuneUploaderBase):
         )
         self.CLIENT_ID = self.env.get("CLIENT_ID")
         self.CLIENT_SECRET = self.env.get("CLIENT_SECRET")
+        self.CLIENT_CERTIFICATE_PATH = self.env.get("CLIENT_CERTIFICATE_PATH")
+        self.CLIENT_CERTIFICATE_PASSWORD = self.env.get("CLIENT_CERTIFICATE_PASSWORD")
         self.TENANT_ID = self.env.get("TENANT_ID")
         app_name = self.env.get("display_name")
         app_blacklist_versions = self.env.get("blacklist_versions")
@@ -88,7 +90,11 @@ class IntuneAppPromoter(IntuneUploaderBase):
 
         # Get access token
         self.token = self.obtain_accesstoken(
-            self.CLIENT_ID, self.CLIENT_SECRET, self.TENANT_ID
+            self.CLIENT_ID,
+            self.CLIENT_SECRET,
+            self.TENANT_ID,
+            cert_path=self.CLIENT_CERTIFICATE_PATH,
+            cert_password=self.CLIENT_CERTIFICATE_PASSWORD,
         )
 
         # Check if promotion info is set

--- a/IntuneUploader/IntuneAppUploader.py
+++ b/IntuneUploader/IntuneAppUploader.py
@@ -34,8 +34,16 @@ class IntuneAppUploader(IntuneUploaderBase):
             "description": "The client ID to use for authenticating the request.",
         },
         "CLIENT_SECRET": {
-            "required": True,
-            "description": "The client secret to use for authenticating the request.",
+            "required": False,
+            "description": "The client secret to use for authenticating the request. Required when not using certificate authentication.",
+        },
+        "CLIENT_CERTIFICATE_PATH": {
+            "required": False,
+            "description": "Path to a PEM or PKCS#12 (.pfx/.p12) file containing both the private key and certificate. When set, certificate authentication is used and CLIENT_SECRET is ignored.",
+        },
+        "CLIENT_CERTIFICATE_PASSWORD": {
+            "required": False,
+            "description": "Password for the certificate file, if encrypted.",
         },
         "TENANT_ID": {
             "required": True,
@@ -167,6 +175,8 @@ class IntuneAppUploader(IntuneUploaderBase):
         )
         self.CLIENT_ID = self.env.get("CLIENT_ID")
         self.CLIENT_SECRET = self.env.get("CLIENT_SECRET")
+        self.CLIENT_CERTIFICATE_PATH = self.env.get("CLIENT_CERTIFICATE_PATH")
+        self.CLIENT_CERTIFICATE_PASSWORD = self.env.get("CLIENT_CERTIFICATE_PASSWORD")
         self.TENANT_ID = self.env.get("TENANT_ID")
         self.RECIPE_CACHE_DIR = self.env.get("RECIPE_CACHE_DIR")
         # Set the content_updated variable to false
@@ -202,7 +212,11 @@ class IntuneAppUploader(IntuneUploaderBase):
 
         # Get the access token
         self.token = self.obtain_accesstoken(
-            self.CLIENT_ID, self.CLIENT_SECRET, self.TENANT_ID
+            self.CLIENT_ID,
+            self.CLIENT_SECRET,
+            self.TENANT_ID,
+            cert_path=self.CLIENT_CERTIFICATE_PATH,
+            cert_password=self.CLIENT_CERTIFICATE_PASSWORD,
         )
 
         @dataclass

--- a/IntuneUploader/IntuneScriptUploader.py
+++ b/IntuneUploader/IntuneScriptUploader.py
@@ -130,6 +130,8 @@ class IntuneScriptUploader(IntuneUploaderBase):
         )
         self.CLIENT_ID = self.env.get("CLIENT_ID")
         self.CLIENT_SECRET = self.env.get("CLIENT_SECRET")
+        self.CLIENT_CERTIFICATE_PATH = self.env.get("CLIENT_CERTIFICATE_PATH")
+        self.CLIENT_CERTIFICATE_PASSWORD = self.env.get("CLIENT_CERTIFICATE_PASSWORD")
         self.TENANT_ID = self.env.get("TENANT_ID")
         script_path = self.env.get("script_path")
         script_description = self.env.get("description")
@@ -155,7 +157,11 @@ class IntuneScriptUploader(IntuneUploaderBase):
 
         # Get token
         self.token = self.obtain_accesstoken(
-            self.CLIENT_ID, self.CLIENT_SECRET, self.TENANT_ID
+            self.CLIENT_ID,
+            self.CLIENT_SECRET,
+            self.TENANT_ID,
+            cert_path=self.CLIENT_CERTIFICATE_PATH,
+            cert_password=self.CLIENT_CERTIFICATE_PASSWORD,
         )
 
         @dataclass

--- a/IntuneUploader/IntuneUploaderLib/IntuneUploaderBase.py
+++ b/IntuneUploader/IntuneUploaderLib/IntuneUploaderBase.py
@@ -24,18 +24,35 @@ class IntuneUploaderBase(Processor):
     """IntuneUploaderBase processor"""
 
     def obtain_accesstoken(
-        self, client_id: str, client_secret: str, tenant_id: str
+        self,
+        client_id: str,
+        client_secret: str,
+        tenant_id: str,
+        cert_path: str = None,
+        cert_password: str = None,
     ) -> dict:
         """This function obtains an access token from the Microsoft Graph API.
 
+        If cert_path is provided, certificate-based authentication is used and
+        client_secret is ignored. Otherwise the client_id/client_secret flow is used.
+
         Args:
             client_id (str): The client ID to use for authenticating the request.
-            client_secret (str): The client secret to use for authenticating the request.
+            client_secret (str): The client secret. Ignored when cert_path is set.
             tenant_id (str): The tenant ID to use for authenticating the request.
+            cert_path (str, optional): Path to a PEM or PKCS#12 (.pfx/.p12) file
+                containing both the private key and certificate. Defaults to None.
+            cert_password (str, optional): Password protecting the private key or
+                PKCS#12 file. Defaults to None.
 
         Returns:
             dict: The response from the request as a dictionary.
         """
+
+        if cert_path:
+            return self._obtain_accesstoken_cert(
+                client_id, tenant_id, cert_path, cert_password
+            )
 
         url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
@@ -54,6 +71,84 @@ class IntuneUploaderBase(Processor):
             )
         response = json.loads(response.text)
         return response
+
+    def _obtain_accesstoken_cert(
+        self,
+        client_id: str,
+        tenant_id: str,
+        cert_path: str,
+        cert_password: str = None,
+    ) -> dict:
+        """Obtains an access token using certificate-based authentication.
+
+        Loads the certificate from PEM or PKCS#12, computes the SHA-1 thumbprint,
+        and uses MSAL to acquire a token via signed JWT client assertion. The
+        public certificate is included to enable Subject Name + Issuer (SNI)
+        authentication, which Microsoft recommends and which supports cert rollover.
+        """
+        try:
+            import msal
+        except ImportError:
+            raise ProcessorError(
+                "Certificate authentication requires the 'msal' package. "
+                "Install with: /usr/local/autopkg/python -m pip install msal"
+            )
+
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.serialization import pkcs12
+
+        with open(cert_path, "rb") as f:
+            cert_data = f.read()
+        password_bytes = cert_password.encode() if cert_password else None
+
+        if cert_path.lower().endswith((".pfx", ".p12")):
+            private_key_obj, certificate, _ = pkcs12.load_key_and_certificates(
+                cert_data, password_bytes
+            )
+        else:
+            private_key_obj = serialization.load_pem_private_key(
+                cert_data, password_bytes
+            )
+            try:
+                certificate = x509.load_pem_x509_certificate(cert_data)
+            except ValueError:
+                certificate = None
+
+        if private_key_obj is None or certificate is None:
+            raise ProcessorError(
+                f"Certificate file {cert_path} must contain both a private key "
+                "and an X.509 certificate."
+            )
+
+        private_key_pem = private_key_obj.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode()
+        thumbprint = certificate.fingerprint(hashes.SHA1()).hex()
+        public_cert_pem = certificate.public_bytes(
+            serialization.Encoding.PEM
+        ).decode()
+
+        app = msal.ConfidentialClientApplication(
+            client_id,
+            authority=f"https://login.microsoftonline.com/{tenant_id}",
+            client_credential={
+                "private_key": private_key_pem,
+                "thumbprint": thumbprint,
+                "public_certificate": public_cert_pem,
+            },
+        )
+        result = app.acquire_token_for_client(
+            scopes=["https://graph.microsoft.com/.default"]
+        )
+        if "access_token" not in result:
+            raise ProcessorError(
+                "Failed to obtain access token: "
+                f"{result.get('error_description', result)}"
+            )
+        return result
 
     def makeapirequest(self, endpoint: str, token: dict, q_param=None) -> dict:
         """This function makes a request to the Graph API and returns the response as a dictionary.

--- a/IntuneUploader/IntuneVTAppDeleter.py
+++ b/IntuneUploader/IntuneVTAppDeleter.py
@@ -58,6 +58,8 @@ class IntuneVTAppDeleter(IntuneUploaderBase):
         )
         self.CLIENT_ID = self.env.get("CLIENT_ID")
         self.CLIENT_SECRET = self.env.get("CLIENT_SECRET")
+        self.CLIENT_CERTIFICATE_PATH = self.env.get("CLIENT_CERTIFICATE_PATH")
+        self.CLIENT_CERTIFICATE_PASSWORD = self.env.get("CLIENT_CERTIFICATE_PASSWORD")
         self.TENANT_ID = self.env.get("TENANT_ID")
         positives = self.env.get("positives")
         app_name = self.env.get("display_name")
@@ -77,7 +79,11 @@ class IntuneVTAppDeleter(IntuneUploaderBase):
 
         # Get access token
         self.token = self.obtain_accesstoken(
-            self.CLIENT_ID, self.CLIENT_SECRET, self.TENANT_ID
+            self.CLIENT_ID,
+            self.CLIENT_SECRET,
+            self.TENANT_ID,
+            cert_path=self.CLIENT_CERTIFICATE_PATH,
+            cert_password=self.CLIENT_CERTIFICATE_PASSWORD,
         )
 
         def _get_app():


### PR DESCRIPTION
### Add certificate-based authentication
Adds support for authenticating to Microsoft Graph with a certificate as an alternative to client secret. Existing CLIENT_SECRET-based recipes continue to work unchanged.

### What's new
- New optional inputs: `CLIENT_CERTIFICATE_PATH` and `CLIENT_CERTIFICATE_PASSWORD`
- Supports both PEM and PKCS#12 (.pfx / .p12) certificate files
- Auto-computes the SHA-1 thumbprint from the cert, no extra input needed
- Includes the public cert in the token request to enable Subject Name + Issuer (SNI) auth, which supports cert rollover

#### How it works
If CLIENT_CERTIFICATE_PATH is set, certificate auth is used and CLIENT_SECRET is ignored. Otherwise the existing client-secret flow runs as before.

#### Requirements
Certificate auth depends on [MSAL](https://pypi.org/project/msal/), which is only imported when cert auth is actually used, so secret-based setups need no new dependencies. To enable cert auth:

`/usr/local/autopkg/python -m pip install msal`
Then upload the public certificate to your Entra app registration (App registrations → Certificates & secrets → Certificates).

#### Affected processors
- IntuneAppUploader
- IntuneAppCleaner
- IntuneAppPromoter
- IntuneScriptUploader
- IntuneVTAppDeleter

#### Backward compatibility
Fully backward compatible. `CLIENT_SECRET` is no longer marked required: True on `IntuneAppUploader`, but recipes that set it keep working with no changes.

closes #27 